### PR TITLE
scapy-python3 -> scapy

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Habu requires Python3 and the following packages:
 - regex
 - requests
 - requests-cache
-- scapy-python3
+- scapy
 - websockets
 - matplotlib (Optional, only needed if you want to make some graphs)
 

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Habu requires Python3 and the following packages:
 * regex
 * requests
 * requests-cache
-* scapy-python3
+* scapy
 * websockets
 * matplotlib (Optional, only needed if you want to make some graphs)
 


### PR DESCRIPTION
That's not obvious, but this is scapy: https://pypi.org/project/scapy/
and this isn't: https://pypi.org/project/scapy-python3/ (that's scapy3k undercover 😄 )