### PR TITLE
Fix command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1670,7 +1670,7 @@ Usage: habu.web.tech [OPTIONS] URL
   Note: This tool only sends one request. So, it's stealth and not
   suspicious.
 
-  $ habu.webid https://woocomerce.com
+  $ habu.web.tech https://woocomerce.com
   {
       "Nginx": {
           "categories": [

--- a/README.rst
+++ b/README.rst
@@ -1628,7 +1628,7 @@ habu.web.tech
      Note: This tool only sends one request. So, it's stealth and not
      suspicious.
 
-     $ habu.webid https://woocomerce.com
+     $ habu.web.tech https://woocomerce.com
      {
          "Nginx": {
              "categories": [

--- a/habu/cli/cmd_web_tech.py
+++ b/habu/cli/cmd_web_tech.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
 
 import json
-import os
-import os.path
-from pathlib import Path
 
 import click
 
 from habu.lib.web_tech import web_tech
+
 
 @click.command()
 @click.argument('url')
@@ -21,7 +19,7 @@ def cmd_web_tech(url, no_cache, verbose):
     Note: This tool only sends one request. So, it's stealth and not suspicious.
 
     \b
-    $ habu.webid https://woocomerce.com
+    $ habu.web.tech https://woocomerce.com
     {
         "Nginx": {
             "categories": [
@@ -50,6 +48,7 @@ def cmd_web_tech(url, no_cache, verbose):
 
     response = web_tech(url, no_cache, verbose)
     print(json.dumps(response, indent=4))
+
 
 if __name__ == '__main__':
     cmd_web_tech()


### PR DESCRIPTION
It's `habu.web.tech` instead of `habu.webid`.  Also, unused import were removed.

NB: I updated the README files manually. When I run the scripts then I end up with a lot of whitespace changes. 