### PR TITLE
Add support for reverse/forward DNS lookups

### DIFF
--- a/habu/cli/cmd_dns_forward_lookup.py
+++ b/habu/cli/cmd_dns_forward_lookup.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import sys
+
 import click
 
 from habu.lib.dns import forward_lookup

--- a/habu/cli/cmd_dns_forward_lookup.py
+++ b/habu/cli/cmd_dns_forward_lookup.py
@@ -1,0 +1,37 @@
+"""Perform a forward lookup of a hostname."""
+import json
+import logging
+import sys
+import click
+
+from habu.lib.dns import forward_lookup
+
+
+@click.command()
+@click.argument('hostname')
+@click.option('-v', 'verbose', is_flag=True, default=False, help='Verbose output')
+def cmd_dns_forward_lookup(hostname, verbose):
+    """Perform a forward lookup of a given hostname.
+
+    Example:
+
+    \b
+    $ habu.dns.forward_lookup google.com
+    {
+        "ipv4": "172.217.168.46",
+        "ipv6": "2a00:1450:400a:802::200e"
+    }
+    """
+    if verbose:
+        logging.basicConfig(level=logging.INFO, format='%(message)s')
+        print("Looking up %s..." % hostname, file=sys.stderr)
+
+    answer = forward_lookup(hostname)
+
+    print(json.dumps(answer, indent=4))
+
+    return True
+
+
+if __name__ == '__main__':
+    cmd_dns_forward_lookup()

--- a/habu/cli/cmd_dns_reverse_lookup.py
+++ b/habu/cli/cmd_dns_reverse_lookup.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import sys
+
 import click
 
 from habu.lib.dns import reverse_lookup

--- a/habu/cli/cmd_dns_reverse_lookup.py
+++ b/habu/cli/cmd_dns_reverse_lookup.py
@@ -1,0 +1,39 @@
+"""Perform a reverse lookup of an IP address."""
+import json
+import logging
+import sys
+import click
+
+from habu.lib.dns import reverse_lookup
+
+
+@click.command()
+@click.argument('ip_address')
+@click.option('-v', 'verbose', is_flag=True, default=False, help='Verbose output')
+def cmd_dns_reverse_lookup(ip_address, verbose):
+    """Perform a reverse lookup of a given IP address.
+
+    Example:
+
+    \b
+    $ $ habu.dns.reverse_lookup 8.8.8.8
+    {
+        "hostname": "google-public-dns-a.google.com"
+    }
+    """
+    if verbose:
+        logging.basicConfig(level=logging.INFO, format='%(message)s')
+        print("Looking up %s..." % ip_address, file=sys.stderr)
+
+    answer = reverse_lookup(ip_address)
+
+    if answer:
+        print(json.dumps(answer, indent=4))
+    else:
+        print("[X] %s is not valid IPv4/IPV6 address" % ip_address)
+
+    return True
+
+
+if __name__ == '__main__':
+    cmd_dns_reverse_lookup()

--- a/habu/lib/dns.py
+++ b/habu/lib/dns.py
@@ -1,8 +1,10 @@
-from habu.lib.tomorrow3 import threads
-from dns import reversename, resolver
-from time import sleep
-import socket
 import ipaddress
+import socket
+from time import sleep
+
+from dns import resolver, reversename
+
+from habu.lib.tomorrow3 import threads
 
 
 @threads(50)

--- a/habu/lib/dns.py
+++ b/habu/lib/dns.py
@@ -1,29 +1,58 @@
 from habu.lib.tomorrow3 import threads
-import dns.resolver
-import dns.zone
+from dns import reversename, resolver
 from time import sleep
+import socket
+import ipaddress
 
 
 @threads(50)
 def __threaded_query(hostname):
+    """Perform the requests to the DNS server."""
     try:
-        answer = dns.resolver.query(hostname)
+        answer = resolver.query(hostname)
         return answer
     except Exception:
         return None
 
 
 def query_bulk(names):
-
+    """Query server with multiple entries."""
     answers = [__threaded_query(name) for name in names]
 
     while True:
-        if all([ a.done() for a in answers]):
+        if all([a.done() for a in answers]):
             break
         sleep(1)
 
     return [answer.result() for answer in answers]
 
-    #for answer in answers:
-    #    print(answer.result())
 
+def reverse_lookup(ip_address):
+    """Perform a reverse lookup of IP address."""
+    try:
+        type(ipaddress.ip_address(ip_address))
+    except ValueError:
+        return {}
+
+    record = reversename.from_address(ip_address)
+    hostname = str(resolver.query(record, "PTR")[0])[:-1]
+    return {'hostname': hostname}
+
+
+def forward_lookup(name):
+    """Perform a forward lookup of a hostname."""
+    ip_addresses = {}
+
+    addresses = list(set(str(ip[4][0]) for ip in socket.getaddrinfo(
+        name, None)))
+
+    if addresses is None:
+        return ip_addresses
+
+    for address in addresses:
+        if type(ipaddress.ip_address(address)) is ipaddress.IPv4Address:
+            ip_addresses['ipv4'] = address
+        if type(ipaddress.ip_address(address)) is ipaddress.IPv6Address:
+            ip_addresses['ipv6'] = address
+
+    return ip_addresses

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ setup(
         habu.cve.2018.9995=habu.cli.cmd_cve_2018_9995:cmd_cve_2018_9995
         habu.dhcp.discover=habu.cli.cmd_dhcp_discover:cmd_dhcp_discover
         habu.dhcp.starvation=habu.cli.cmd_dhcp_starvation:cmd_dhcp_starvation
+        habu.dns.forward_lookup=habu.cli.cmd_dns_forward_lookup:cmd_dns_forward_lookup
+        habu.dns.reverse_lookup=habu.cli.cmd_dns_reverse_lookup:cmd_dns_reverse_lookup
         habu.eicar=habu.cli.cmd_eicar:cmd_eicar
         habu.extract.hostname=habu.cli.cmd_extract_hostname:cmd_extract_hostname
         habu.extract.ipv4=habu.cli.cmd_extract_ipv4:cmd_extract_ipv4


### PR DESCRIPTION
```bash
$ habu.dns.reverse_lookup 8.8.8.8
{
    "hostname": "google-public-dns-a.google.com"
}
$ habu.dns.forward_lookup google.com
{
    "ipv6": "2a00:1450:400a:801::200e",
    "ipv4": "172.217.168.14"
}
```

Please consider this a MVP and not a full-blown implementation. Doc update still pending.