### PR TITLE
New HTTP related commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,9 @@ Commands Index
 * `forkbomb <#habuforkbomb>`_
 * `gateway.find <#habugatewayfind>`_
 * `hasher <#habuhasher>`_
+* `http.headers <#habuhttpheaders>`_
+* `http.options <#habuhttpoptions>`_
+* `http.subjugation <#habuhttpsubjugation>`_
 * `ip <#habuip>`_
 * `ip2asn <#habuip2asn>`_
 * `isn <#habuisn>`_
@@ -942,6 +945,106 @@ habu.hasher
       --help                          Show this message and exit.
     
 
+habu.http.headers
+-----------------
+
+.. code-block::
+
+    Usage: habu.http.headers [OPTIONS] SERVER
+    
+      Retrieve the HTTP headers of a web server.
+    
+      Example:
+    
+      $ habu.http.headers http://duckduckgo.com
+      {
+          "Server": "nginx",
+          "Date": "Sun, 14 Apr 2019 00:00:55 GMT",
+          "Content-Type": "text/html",
+          "Content-Length": "178",
+          "Connection": "keep-alive",
+          "Location": "https://duckduckgo.com/",
+          "X-Frame-Options": "SAMEORIGIN",
+          "Content-Security-Policy": "default-src https: blob: data: 'unsafe-inline' 'unsafe-eval'",
+          "X-XSS-Protection": "1;mode=block",
+          "X-Content-Type-Options": "nosniff",
+          "Referrer-Policy": "origin",
+          "Expect-CT": "max-age=0",
+          "Expires": "Mon, 13 Apr 2020 00:00:55 GMT",
+          "Cache-Control": "max-age=31536000"
+      }
+    
+    Options:
+      -v      Verbose output
+      --help  Show this message and exit.
+    
+
+habu.http.options
+-----------------
+
+.. code-block::
+
+    Usage: habu.http.options [OPTIONS] SERVER
+    
+      Retrieve the available HTTP methods of a web server.
+    
+      Example:
+    
+      $ habu.http.options -v http://google.com
+      {
+          "allowed": "GET, HEAD"
+      }
+    
+    Options:
+      -v      Verbose output
+      --help  Show this message and exit.
+    
+
+habu.http.subjugation
+---------------------
+
+.. code-block::
+
+    Usage: habu.http.subjugation [OPTIONS] SERVER
+    
+      Retrieve the redirect location of a web server.
+    
+      Example:
+    
+      $ habu.http.subjugation http://duckduckgo.com
+      {
+          "redirect": "https://duckduckgo.com/"
+      }
+    
+      $ habu.http.subjugation -f http://duckduckgo.com
+      {
+          "redirect": "https://duckduckgo.com/",
+          "headers": {
+              "Server": "nginx",
+              "Date": "Wed, 17 Apr 2019 16:39:00 GMT",
+              "Content-Type": "text/html; charset=UTF-8",
+              "Connection": "keep-alive",
+              "Vary": "Accept-Encoding",
+              "ETag": "W/\"5cb6a8b7-1529\"",
+              "Strict-Transport-Security": "max-age=31536000",
+              "X-Frame-Options": "SAMEORIGIN",
+              "Content-Security-Policy": "default-src https: blob: ...",
+              "X-XSS-Protection": "1;mode=block",
+              "X-Content-Type-Options": "nosniff",
+              "Referrer-Policy": "origin",
+              "Expect-CT": "max-age=0",
+              "Expires": "Wed, 17 Apr 2019 16:38:59 GMT",
+              "Cache-Control": "no-cache",
+              "Content-Encoding": "gzip"
+          }
+      }
+
+    Options:
+      -f      Follow the redirect.
+      -v      Verbose output.
+      --help  Show this message and exit.
+    
+
 habu.ip
 -------
 
@@ -1021,51 +1124,6 @@ habu.jshell
 
 .. code-block::
 
-    Usage: habu.jshell [OPTIONS]
-    
-      Control a web browser through Websockets.
-    
-      Bind a port (default: 3333) and listen for HTTP connections.
-    
-      On connection, send a JavaScript code that opens a WebSocket that can be
-      used to send commands to the connected browser.
-    
-      You can write the commands directly in the shell, or use plugins, that are
-      simply external JavaScript files.
-    
-      Using habu.jshell you can completely control a web browser.
-    
-      Reference: https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API
-    
-      Example:
-    
-      $ habu.jshell
-      >> Listening on 192.168.0.10:3333. Waiting for a victim connection.
-      >> HTTP Request received from 192.168.0.15. Sending hookjs
-      >> Connection from 192.168.0.15
-      $ _sessions
-      0 * 192.168.0.15:33432 Mozilla/5.0 (X11; Linux x86_64; rv:57.0) Gecko/20100101 Firefox/57.0
-      $ _info
-      {
-          "user-agent": "Mozilla/5.0 (X11; Linux x86_64; rv:57.0) Gecko/20100101 Firefox/57.0",
-          "location": "http://192.168.0.10:3333/",
-          "java-enabled": false,
-          "platform": "Linux x86_64",
-          "app-code-name": "Mozilla",
-          "app-name": "Netscape",
-          "app-version": "5.0 (X11)",
-          "cookie-enabled": true,
-          "language": "es-AR",
-          "online": true
-      }
-      $ document.location
-      http://192.168.0.10:3333/
-    
-    Options:
-      -v          Verbose
-      -i TEXT     IP to listen on
-      -p INTEGER  Port to listen on
-      --help      Show this message and exit.
     
 
 habu.karma
@@ -1675,22 +1733,24 @@ habu.web.report
 
 .. code-block::
 
-    Usage: habu.web.report [OPTIONS] [F]
+    Usage: habu.web.report [OPTIONS] [URLS]
     
-      Uses Firefox to take a screenshot of the websites. (you need firefox
-      installed, obviously)
+      Use a browser to take a screenshot of the websites.
     
       Makes a report that includes the HTTP headers.
     
-      The expected format is one url per line.
+      The expected format for the input file is one URL per line.
     
-      Creates a directory called 'report' with the content inside.
+      Create a directory called 'report' with the content inside.
     
       $ echo https://www.portantier.com | habu.web.report
     
+      $ habu.web.report urls.txt
+    
     Options:
-      -v      Verbose output
-      --help  Show this message and exit.
+      -v                             Verbose output.
+      -b [firefox|chromium-browser]  Browser to use for screenshot.
+      --help                         Show this message and exit.
     
 
 habu.web.screenshot
@@ -1700,13 +1760,16 @@ habu.web.screenshot
 
     Usage: habu.web.screenshot [OPTIONS] URL
     
-      Uses Firefox to take a screenshot (you need firefox installed, obviously)
+      Use a browser to take a screenshot.
+    
+      You need a browser installed, obviously.
     
       $ habu.web.screenshot https://www.portantier.com
     
     Options:
-      -o TEXT  Output file. (default: screenshot.png)
-      --help   Show this message and exit.
+      -o TEXT                        Output file. (default: screenshot.png)
+      -b [firefox|chromium-browser]  Browser to use for screenshot.
+      --help                         Show this message and exit.
     
 
 habu.web.tech

--- a/habu/cli/cmd_http_headers.py
+++ b/habu/cli/cmd_http_headers.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+import json
+import logging
+import sys
+
+import click
+
+from habu.lib.http import get_headers
+
+
+@click.command()
+@click.argument('server')
+@click.option('-v', 'verbose', is_flag=True, default=False, help='Verbose output')
+def cmd_http_headers(server, verbose):
+    """Retrieve the HTTP headers of a web server.
+
+    Example:
+
+    \b
+    $ habu.http.headers http://duckduckgo.com
+    {
+        "Server": "nginx",
+        "Date": "Sun, 14 Apr 2019 00:00:55 GMT",
+        "Content-Type": "text/html",
+        "Content-Length": "178",
+        "Connection": "keep-alive",
+        "Location": "https://duckduckgo.com/",
+        "X-Frame-Options": "SAMEORIGIN",
+        "Content-Security-Policy": "default-src https: blob: data: 'unsafe-inline' 'unsafe-eval'",
+        "X-XSS-Protection": "1;mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Referrer-Policy": "origin",
+        "Expect-CT": "max-age=0",
+        "Expires": "Mon, 13 Apr 2020 00:00:55 GMT",
+        "Cache-Control": "max-age=31536000"
+    }
+    """
+    if verbose:
+        logging.basicConfig(level=logging.INFO, format='%(message)s')
+
+    if verbose:
+        print("[-] Retrieving the HTTP headers of the server...")
+
+    headers = get_headers(server)
+
+    if headers is not False:
+        print(json.dumps(headers, indent=4))
+    else:
+        print("[X] URL {} is not valid!", file=sys.stderr)
+
+    if verbose:
+        print("[+] HTTP headers from {} retrieved".format(server))
+
+    return True
+
+
+if __name__ == '__main__':
+    cmd_http_headers()

--- a/habu/cli/cmd_http_options.py
+++ b/habu/cli/cmd_http_options.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import json
+import logging
+import sys
+
+import click
+
+from habu.lib.http import get_options
+
+
+@click.command()
+@click.argument('server')
+@click.option('-v', 'verbose', is_flag=True, default=False, help='Verbose output')
+def cmd_http_options(server, verbose):
+    """Retrieve the available HTTP methods of a web server.
+
+    Example:
+
+    \b
+    $ habu.http.options -v http://google.com
+    {
+        "allowed": "GET, HEAD"
+    }
+    """
+    if verbose:
+        logging.basicConfig(level=logging.INFO, format='%(message)s')
+
+    if verbose:
+        print("[-] Retrieving the HTTP headers of the server...")
+
+    options = get_options(server)
+
+    if type(options) is dict:
+        print(json.dumps(options, indent=4))
+        if verbose:
+            print("[+] HTTP options from {} retrieved".format(server))
+    else:
+        print("[X] {}".format(options), file=sys.stderr)
+
+    return True
+
+
+if __name__ == '__main__':
+    cmd_http_options()

--- a/habu/cli/cmd_http_subjugation.py
+++ b/habu/cli/cmd_http_subjugation.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import json
+import logging
+import sys
+
+import click
+
+from habu.lib.http import get_headers, subjugation
+
+
+@click.command()
+@click.argument('server')
+@click.option('-f', 'follow', is_flag=True, default=False,
+              help='Follow the redirect.')
+@click.option('-v', 'verbose', is_flag=True, default=False,
+              help='Verbose output.')
+def cmd_http_subjugation(server, follow, verbose):
+    """Retrieve the redirect location of a web server.
+
+    Example:
+
+    \b
+    $ habu.http.subjugation http://duckduckgo.com
+    {
+        "redirect": "https://duckduckgo.com/"
+    }
+
+    $ habu.http.subjugation -f http://duckduckgo.com
+    {
+        "redirect": "https://duckduckgo.com/",
+        "headers": {
+            "Server": "nginx",
+            "Date": "Wed, 17 Apr 2019 09:05:44 GMT",
+            "Content-Type": "text/html; charset=UTF-8",
+            "Connection": "keep-alive",
+            "Vary": "Accept-Encoding",
+            "ETag": "W/\"5cb6a8b8-1529\"",
+            "Strict-Transport-Security": "max-age=31536000",
+            "X-Frame-Options": "SAMEORIGIN",
+            "Content-Security-Policy": "default-src https: blob: ...",
+            "X-XSS-Protection": "1;mode=block",
+            "X-Content-Type-Options": "nosniff",
+            "Referrer-Policy": "origin",
+            "Expect-CT": "max-age=0",
+            "Expires": "Wed, 17 Apr 2019 09:05:43 GMT",
+            "Cache-Control": "no-cache",
+            "Content-Encoding": "gzip"
+        }
+    }
+    """
+    if verbose:
+        logging.basicConfig(level=logging.INFO, format='%(message)s')
+
+    if verbose:
+        print("[-] Retrieving the HTTP location of the server...")
+
+    location = subjugation(server)
+
+    if location is not False:
+        if follow:
+            redirect = get_headers(location['redirect'])
+            location['headers'] = redirect
+            print(json.dumps(location, indent=4))
+        else:
+            print(json.dumps(location, indent=4))
+    else:
+        print("[X] URL {} is not valid!", file=sys.stderr)
+
+    if verbose:
+        print("[+] HTTP headers from {} retrieved".format(server))
+
+    return True
+
+
+if __name__ == '__main__':
+    cmd_http_subjugation()

--- a/habu/cli/cmd_web_report.py
+++ b/habu/cli/cmd_web_report.py
@@ -2,32 +2,42 @@
 
 import html
 import sys
-import urllib.request
 from pathlib import Path
 
 import click
+from json2table import convert
 
+from habu.lib.http import get_headers, get_options
 from habu.lib.web_screenshot import web_screenshot
 
 
 @click.command()
-@click.option('-v', 'verbose', is_flag=True, default=False, help='Verbose output')
-@click.argument('f', type=click.File('rb'), default='-')
-def cmd_web_report(f, verbose):
-    """Uses Firefox to take a screenshot of the websites. (you need firefox installed, obviously)
+@click.option('-v', 'verbose', is_flag=True, default=False,
+              help='Verbose output.')
+@click.argument('urls', type=click.File('rb'), default='-')
+@click.option('-b', 'browser', default='firefox',
+              type=click.Choice(['firefox', 'chromium-browser']),
+              help='Browser to use for screenshot.')
+def cmd_web_report(urls, browser, verbose):
+    """Use a browser to take a screenshot of the websites.
 
     Makes a report that includes the HTTP headers.
 
-    The expected format is one url per line.
+    The expected format for the input file is one URL per line.
 
-    Creates a directory called 'report' with the content inside.
+    Create a directory called 'report' with the content inside.
 
     \b
     $ echo https://www.portantier.com | habu.web.report
+
+    $ habu.web.report urls.txt
     """
-
-    urls = f.read().decode().strip().split('\n')
-
+    table_attributes = {
+        "style": "width:100%,text-align:left",
+        "class": "table table-striped",
+    }
+    build_direction = "LEFT_TO_RIGHT"
+    urls = urls.read().decode().strip().split('\n')
     report_dir = Path('report')
 
     try:
@@ -43,36 +53,35 @@ def cmd_web_report(f, verbose):
         outfile.write('<meta charset=utf-8>\n')
         outfile.write('<title>habu.web.report</title>\n')
         outfile.write('<body>\n')
-        outfile.write('<table border=1 style="max-width: 100%">\n')
 
-        for i,url in enumerate(sorted(urls)):
+        for index, url in enumerate(sorted(urls)):
+            print(index, url, file=sys.stderr)
 
-            error = False
-
-            print(i, url, file=sys.stderr)
-
-            outfile.write('<tr>\n')
-            outfile.write('<td style="vertical-align:top;max-width:30%">\n')
-            outfile.write('<p><strong>' + html.escape(url) + '</strong></p>\n')
-
+            outfile.write('<h1>' + html.escape(url) + '</h1>\n')
             try:
-                req = urllib.request.Request(url, method='HEAD')
-                resp = urllib.request.urlopen(req)
-                outfile.write('<pre style="white-space: pre-wrap;">' + html.escape(str(resp.headers)) + '</pre>\n')
-            except Exception as e:
-                outfile.write('<pre>ERROR: ' + html.escape(str(e)) + '</pre>\n')
-                error = True
+                outfile.write('<h2>Headers</h2>\n')
+                headers = get_headers(url)
+                outfile.write(convert(
+                    headers, build_direction=build_direction,
+                    table_attributes=table_attributes))
+                outfile.write('\n')
+                outfile.write('<h2>Allowed options</h2>\n')
+                options = get_options(url)
+                outfile.write(convert(options))
+                outfile.write('\n')
+            except AttributeError:
+                outfile.write('<pre>ERROR: Unable to retrieve details</pre>\n')
 
-            outfile.write('</td><td>')
+            outfile.write('<h2>Screenshot</h2>\n')
+            web_screenshot(url, report_dir / '{}.png'.format(index), browser)
 
-            if not error:
-                web_screenshot(url, report_dir / '{}.png'.format(i))
-                outfile.write('<img src={}.png style="max-width: 100%" />\n'.format(i))
+            if (report_dir / '{}.png'.format(index)).is_file():
+                outfile.write(
+                    '<p><img src={}.png style="max-width:80%"/></p>\n'.format(index))
+            else:
+                outfile.write(
+                    '<pre>ERROR: Unable to create screenshot</pre>\n')
 
-            outfile.write('</td>\n')
-            outfile.write('</tr>\n')
-
-        outfile.write('</table>\n')
         outfile.write('</body>\n')
         outfile.write('</html>\n')
 

--- a/habu/cli/cmd_web_screenshot.py
+++ b/habu/cli/cmd_web_screenshot.py
@@ -15,14 +15,20 @@ from habu.lib.web_screenshot import web_screenshot
 @click.command()
 @click.argument('url')
 @click.option('-o', 'outfile', default='screenshot.png', help='Output file. (default: screenshot.png)')
-def cmd_web_screenshot(url, outfile):
-    """Uses Firefox to take a screenshot (you need firefox installed, obviously)
+@click.option('-b', 'browser', default='firefox',
+              type=click.Choice(['firefox', 'chromium-browser']),
+              help='Browser to use for screenshot.')
+def cmd_web_screenshot(url, outfile, browser):
+    """Use a browser to take a screenshot.
+
+    You need a browser installed, obviously.
 
     \b
     $ habu.web.screenshot https://www.portantier.com
     """
 
-    web_screenshot(url, outfile)
+    web_screenshot(url, outfile, browser)
+
 
 if __name__ == '__main__':
     cmd_web_screenshot()

--- a/habu/lib/http.py
+++ b/habu/lib/http.py
@@ -1,0 +1,38 @@
+"""Retrieve details of a HTTP server."""
+import requests
+import urllib3
+
+urllib3.disable_warnings()
+
+
+def get_headers(server):
+    """Retrieve all HTTP headers"""
+    try:
+        response = requests.head(
+            server, allow_redirects=False, verify=False, timeout=5)
+    except requests.exceptions.ConnectionError:
+        return False
+
+    return dict(response.headers)
+
+
+def subjugation(server):
+    """Check if the URL is redirected."""
+    headers = get_headers(server)
+    if 'Location' in headers:
+        return {'redirect': headers['Location']}
+
+
+def get_options(server):
+    """Retrieve the available HTTP verbs"""
+    try:
+        response = requests.options(
+            server, allow_redirects=False, verify=False, timeout=5)
+    except (requests.exceptions.ConnectionError,
+            requests.exceptions.MissingSchema):
+        return "Server {} is not available!".format(server)
+
+    try:
+        return {'allowed': response.headers['Allow']}
+    except KeyError:
+        return "Unable to get HTTP methods"

--- a/habu/lib/web_screenshot.py
+++ b/habu/lib/web_screenshot.py
@@ -35,7 +35,6 @@ def web_screenshot(url, outfile, browser):
     with subprocess.Popen(screenshot_cmd, stderr=subprocess.DEVNULL) as proc:
         for count in range(DURATION):
             sleep(1)
-            print(count)
             if outfile.is_file():
                 break
 

--- a/habu/lib/web_screenshot.py
+++ b/habu/lib/web_screenshot.py
@@ -7,38 +7,41 @@ from pathlib import Path
 from shutil import which
 from time import sleep
 
+DURATION = 20
 
-def web_screenshot(url, outfile):
 
-    if not which('firefox'):
-        print('You don\'t have firefox in your PATH.', file=sys.stderr)
+def web_screenshot(url, outfile, browser):
+    """Create a screenshot of a website."""
+    if not which(browser):
+        print("You don't have {} in your PATH".format(browser), file=sys.stderr)
         return False
 
+    screenshot_cmd = ''
+    profile_firefox = shlex.split('firefox --new-instance --CreateProfile habu.web.screenshot')
+    screenshot_firefox = shlex.split('firefox --new-instance --headless -P habu.web.screenshot --screenshot {} {}'.format(outfile, url))
+    screenshot_chromium = shlex.split('chromium-browser --headless --disable-gpu --window-size=1440,900 --screenshot={} {}'.format(outfile, url))
+
+    if browser == 'firefox':
+        screenshot_cmd = screenshot_firefox
+        subprocess.Popen(profile_firefox, stderr=subprocess.DEVNULL)
+
+    if browser == 'chromium-browser':
+        screenshot_cmd = screenshot_chromium
+
     outfile = Path(outfile)
-
-    profile_cmd = shlex.split('firefox --new-instance --CreateProfile habu.web.screenshot')
-    screenshot_cmd = shlex.split('firefox --new-instance --headless -P habu.web.screenshot --screenshot {} {}'.format(outfile, url))
-
-    subprocess.Popen(profile_cmd, stderr=subprocess.DEVNULL)
-
-    try:
+    if outfile.is_file():
         outfile.unlink()
-    except FileNotFoundError:
-        pass
 
     with subprocess.Popen(screenshot_cmd, stderr=subprocess.DEVNULL) as proc:
-
-        for i in range(20):
-
+        for count in range(DURATION):
             sleep(1)
-
+            print(count)
             if outfile.is_file():
                 break
 
-            if i == 19:
-                print('Error', file=sys.stderr)
-                return False
+            if count == DURATION - 1:
+                print("Unable to create screenshot", file=sys.stderr)
+                break
 
         proc.kill()
-
     return True

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'cryptography',
         'click',
         'dnspython',
+        'json2table',
         'lxml',
         #'prompt_toolkit==1.0.15',
         'pycrypto',


### PR DESCRIPTION
Get details about a HTTP server.

* `http.headers`
* `http.options`
* `http.subjugation`

Those are standalone commands but also used for `habu.web.report`.

`habu.web.report` now supports `chromium-browser` to create the screenshots while `firefox` is still the default.

Unfortunately is [json2table](https://pypi.org/project/json2table/) a new dependency. 
