### PR TITLE
Get the local IP address(es) of the local interfaces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,7 @@ Commands Index
 * `hasher <#habuhasher>`_
 * `ip <#habuip>`_
 * `ip2asn <#habuip2asn>`_
+* `ip.internal <#habuipinternal>`_
 * `isn <#habuisn>`_
 * `jshell <#habujshell>`_
 * `karma <#habukarma>`_
@@ -947,19 +948,6 @@ habu.ip
 
 .. code-block::
 
-    Usage: habu.ip [OPTIONS]
-    
-      Get the public IP address of the connection from https://api.ipify.org.
-    
-      Example:
-    
-      $ habu.ip
-      {
-          "ip_external": "80.219.53.185"
-      }
-    
-    Options:
-      --help  Show this message and exit.
     
 
 habu.ip2asn
@@ -984,6 +972,47 @@ habu.ip2asn
       }
     
     Options:
+      --help  Show this message and exit.
+    
+
+habu.ip.internal
+----------------
+
+.. code-block::
+
+    Usage: habu.ip.internal [OPTIONS]
+    
+      Get the local IP address(es) of the local interfaces.
+    
+      Example:
+    
+      $ habu.ip.internal
+      {
+        "lo": {
+          "ipv4": [
+            {
+              "addr": "127.0.0.1",
+              "netmask": "255.0.0.0",
+              "peer": "127.0.0.1"
+            }
+          ],
+          "link_layer": [
+            {
+              "addr": "00:00:00:00:00:00",
+              "peer": "00:00:00:00:00:00"
+            }
+          ],
+          "ipv6": [
+            {
+              "addr": "::1",
+              "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128"
+            }
+          ]
+        },
+      ...
+    
+    Options:
+      -v      Verbose output.
       --help  Show this message and exit.
     
 
@@ -1021,51 +1050,6 @@ habu.jshell
 
 .. code-block::
 
-    Usage: habu.jshell [OPTIONS]
-    
-      Control a web browser through Websockets.
-    
-      Bind a port (default: 3333) and listen for HTTP connections.
-    
-      On connection, send a JavaScript code that opens a WebSocket that can be
-      used to send commands to the connected browser.
-    
-      You can write the commands directly in the shell, or use plugins, that are
-      simply external JavaScript files.
-    
-      Using habu.jshell you can completely control a web browser.
-    
-      Reference: https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API
-    
-      Example:
-    
-      $ habu.jshell
-      >> Listening on 192.168.0.10:3333. Waiting for a victim connection.
-      >> HTTP Request received from 192.168.0.15. Sending hookjs
-      >> Connection from 192.168.0.15
-      $ _sessions
-      0 * 192.168.0.15:33432 Mozilla/5.0 (X11; Linux x86_64; rv:57.0) Gecko/20100101 Firefox/57.0
-      $ _info
-      {
-          "user-agent": "Mozilla/5.0 (X11; Linux x86_64; rv:57.0) Gecko/20100101 Firefox/57.0",
-          "location": "http://192.168.0.10:3333/",
-          "java-enabled": false,
-          "platform": "Linux x86_64",
-          "app-code-name": "Mozilla",
-          "app-name": "Netscape",
-          "app-version": "5.0 (X11)",
-          "cookie-enabled": true,
-          "language": "es-AR",
-          "online": true
-      }
-      $ document.location
-      http://192.168.0.10:3333/
-    
-    Options:
-      -v          Verbose
-      -i TEXT     IP to listen on
-      -p INTEGER  Port to listen on
-      --help      Show this message and exit.
     
 
 habu.karma

--- a/habu/cli/cmd_ip.py
+++ b/habu/cli/cmd_ip.py
@@ -3,7 +3,7 @@ import json
 
 import click
 
-from habu.lib.ip import get_ip
+from habu.lib.ip import get_external_ip
 
 
 @click.command()
@@ -18,7 +18,7 @@ def cmd_ip():
         "ip_external": "80.219.53.185"
     }
     """
-    answer = get_ip()
+    answer = get_external_ip()
 
     print(json.dumps(answer, indent=4))
 

--- a/habu/cli/cmd_ip_internal.py
+++ b/habu/cli/cmd_ip_internal.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+import json
+import logging
+import sys
+
+import click
+
+from habu.lib.ip import get_internal_ip
+
+
+@click.command()
+@click.option('-v', 'verbose', is_flag=True, default=False,
+              help='Verbose output.')
+def cmd_ip_internal(verbose):
+    """Get the local IP address(es) of the local interfaces.
+
+    Example:
+
+    \b
+    $ habu.ip.internal
+    {
+      "lo": {
+        "ipv4": [
+          {
+            "addr": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "peer": "127.0.0.1"
+          }
+        ],
+        "link_layer": [
+          {
+            "addr": "00:00:00:00:00:00",
+            "peer": "00:00:00:00:00:00"
+          }
+        ],
+        "ipv6": [
+          {
+            "addr": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128"
+          }
+        ]
+      },
+    ...
+    """
+    if verbose:
+        logging.basicConfig(level=logging.INFO, format='%(message)s')
+        print("Gathering NIC details...", file=sys.stderr)
+
+    result = get_internal_ip()
+
+    if result:
+        print(json.dumps(result, indent=4))
+    else:
+        print("[X] Unable to get detail about the interfaces")
+
+    return True
+
+
+if __name__ == '__main__':
+    cmd_ip_internal()

--- a/habu/lib/ip.py
+++ b/habu/lib/ip.py
@@ -1,11 +1,35 @@
+from netifaces import (
+    AF_INET, AF_INET6, AF_LINK, gateways, ifaddresses, interfaces)
 import requests
 
 
-def get_ip():
+def get_external_ip():
     """Get the external IP address for the connection."""
     ip_address = requests.get('https://api.ipify.org', timeout=5).text
     return {'ip_external': ip_address}
 
 
+def get_internal_ip():
+    """Get the local IP addresses."""
+    nics = {}
+    for interface_name in interfaces():
+        addresses = ifaddresses(interface_name)
+        try:
+            nics[interface_name] = {
+                'ipv4': addresses[AF_INET],
+                'link_layer': addresses[AF_LINK],
+                'ipv6': addresses[AF_INET6],
+            }
+        except KeyError:
+            pass
+
+    return nics
+
+
+def get_gateways():
+    """Get all gateways for the interfaces."""
+    return gateways()
+
+
 if __name__ == '__main__':
-    print(get_ip())
+    print(get_external_ip())

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         'click',
         'dnspython',
         'lxml',
+        'netifaces',
         #'prompt_toolkit==1.0.15',
         'pycrypto',
         'pygments',


### PR DESCRIPTION
```bash
$ habu.ip.internal
{
    "lo": {
        "ipv4": [
            {
                "addr": "127.0.0.1",
                "netmask": "255.0.0.0",
                "peer": "127.0.0.1"
            }
        ],
        "link_layer": [
            {
                "addr": "00:00:00:00:00:00",
                "peer": "00:00:00:00:00:00"
            }
        ],
        "ipv6": [
            {
                "addr": "::1",
                "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128"
            }
        ]
    },
    "wlp4s0": {
        "ipv4": [
            {
                "addr": "192.168.333.221",
                "netmask": "255.255.255.0",
                "broadcast": "192.168.333.255"
            }
        ],
        "link_layer": [
            {
                "addr": "e4:12:21:21:21:2e",
                "broadcast": "ff:ff:ff:ff:ff:ff"
            }
        ],
        "ipv6": [
            {
                "addr": "fe80::387f:d41e%wlp4s0",
                "netmask": "ffff:ffff:ffff:ffff::/64"
            }
        ]
    },
}
```